### PR TITLE
Sorting headers for deterministic order

### DIFF
--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/wadl/NoJAXBNoWadlTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/wadl/NoJAXBNoWadlTest.java
@@ -35,6 +35,9 @@ import javax.ws.rs.core.Response;
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.util.List;
+import java.util.Arrays;
+import java.util.Collections;
 
 public class NoJAXBNoWadlTest extends JerseyTest {
 
@@ -74,7 +77,9 @@ public class NoJAXBNoWadlTest extends JerseyTest {
 
         try (Response r = target("dummy").request(MediaTypes.WADL_TYPE).options()) {
             String headers = r.getHeaderString(HttpHeaders.ALLOW);
-            Assertions.assertEquals("OPTIONS,PUT", headers);
+            List<String> methods = Arrays.asList(headers.split(","));
+            Collections.sort(methods);
+            Assertions.assertEquals(Arrays.asList("OPTIONS", "PUT"), methods);
         }
         System.out.println(readableStream.toString());
         Assertions.assertEquals(!shouldHaveJaxb,

--- a/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/wadl/NoJAXBNoWadlTest.java
+++ b/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/wadl/NoJAXBNoWadlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
The order of HTTP methods in the `ALLOW` header (OPTIONS,PUT vs PUT,OPTIONS) is not guaranteed to be consistent in `getHeaderString()`, so the following test case fails if the order changes: 

https://github.com/mumbler6/jersey/blob/6da18bd048559bb04975c7e9f4cdf6de5fc59eec/tests/e2e/src/test/java/org/glassfish/jersey/tests/e2e/server/wadl/NoJAXBNoWadlTest.java#L69

To reproduce this problem, you can run the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool with this command:

```
mvn -pl tests/e2e edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=org.glassfish.jersey.tests.e2e.server.wadl.NoJAXBNoWadlTest#testOptionsNoWadl
```

This PR proposes to sort the headers so that the order assumptions (in this PR, alphabetical order) in the test cases are correct.

Please let me know if you want to discuss these changes. 